### PR TITLE
Fix to MemoryDocuentStore behaviour 

### DIFF
--- a/core/src/main/scala/io/reactivecqrs/core/documentstore/MemoryDocumentStore.scala
+++ b/core/src/main/scala/io/reactivecqrs/core/documentstore/MemoryDocumentStore.scala
@@ -48,7 +48,7 @@ sealed trait MemoryDocumentStoreTrait[T <: AnyRef, M <: AnyRef] {
     val tail = arrayPath.tail
     if (tail.isEmpty) {
       innerElement match {
-        case seq: Seq[_] => seq.asInstanceOf[Seq[AnyRef]]
+        case iter: Iterable[_] => iter.asInstanceOf[Iterable[AnyRef]].toSeq
         case _ => Seq()
       }
     } else {

--- a/core/src/test/scala/io/reactivecqrs/core/projection/SubscribableSpec.scala
+++ b/core/src/test/scala/io/reactivecqrs/core/projection/SubscribableSpec.scala
@@ -47,9 +47,9 @@ class SimpleProjection(val eventBusSubscriptionsManager: EventBusSubscriptionsMa
 class SimpleListener(simpleListenerProbe: TestProbe) extends Actor {
   private var subscriptionId: Option[String] = None
   override def receive: Receive = {
-    case SubscribedForProjectionUpdates(code, id) => {
+    case SubscribedForProjectionUpdates(id) => {
       subscriptionId = Some(id)
-      simpleListenerProbe.ref ! SubscribedForProjectionUpdates(code, id)
+      simpleListenerProbe.ref ! SubscribedForProjectionUpdates(id)
     }
     case ProjectionSubscriptionsCancelled(id :: Nil) => {
       if (subscriptionId.get == id) {

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -7,7 +7,7 @@ object Common {
 
     organization := "io.reactivecqrs",
     name := s"reactivecqrs-$moduleName",
-    version := "0.9.17",
+    version := "0.9.18",
     scalaVersion := "2.11.7",
 
     /* required for Scalate to avoid version mismatch */


### PR DESCRIPTION
To make the MemoryDocumentStore.findDocumentByObjectInArray method behave properly if the Document has a field that is not implementation of Seq, but other iterable collection.

Also have found a small bug in test code, which prevented compilation.